### PR TITLE
Improve the Health-checker tool to detect orphaned Data Sync objects.

### DIFF
--- a/AzureSQLDataSyncHealthChecker.ps1
+++ b/AzureSQLDataSyncHealthChecker.ps1
@@ -498,7 +498,7 @@ function ValidateTrigger([String] $trigger) {
                 Write-Host "Trigger" $trigger "exists and is enabled." -Foreground Green
             }
 
-			$query = "sp_helptext '" + $trigger + "'"
+	    $query = "sp_helptext '" + $trigger + "'"
             $MemberCommand.CommandText = $query
             $result = $MemberCommand.ExecuteReader()
             $sphelptextDataTable = new-object 'System.Data.DataTable'


### PR DESCRIPTION
- Improvement - The Data Sync Health-checker tool should be able to identify the objects that were not provisioned using the correct object_id, and were created as part of Restore, Export, etc.
- The table should exist corresponding to whose object_id the trigger was provisioned.
- owner_scope_local_id 0 should exist corresponding to object_id corresponding to which the trigger was provisioned.